### PR TITLE
Refactoring Cloudiscovery CLI to support [provider] [resource] format

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,49 +31,55 @@ The commands generate reports that can be used to further analyze resources.
 
 ### CLI
 
+#### Overview
+
+The CLI runs under the format of `cloudiscovery <platform> <resource> [OPTIONS]`.
+
+#### AWS
+
 1.  Run the cloudiscovery command with following options (if a region not pass, this script will try to get it from ~/.aws/credentials):
 
 1.1 To detect AWS VPC resources (more on [AWS VPC](#aws-vpc)):
 
 ```sh
-cloudiscovery aws-vpc [--vpc-id vpc-xxxxxxx] --region-name xx-xxxx-xxx [--profile-name profile] [--diagram [yes/no]] [--filter xxx] [--verbose]
+cloudiscovery aws vpc [--vpc-id vpc-xxxxxxx] --region-name xx-xxxx-xxx [--profile-name profile] [--diagram [yes/no]] [--filter xxx] [--verbose]
 ```
 1.2 To detect AWS policy resources (more on [AWS Policy](#aws-policy)):
 
 ```sh
-cloudiscovery aws-policy [--profile-name profile] [--diagram [yes/no]] [--filter xxx] [--verbose]
+cloudiscovery aws policy [--profile-name profile] [--diagram [yes/no]] [--filter xxx] [--verbose]
 ```
 1.3 To detect AWS IoT resources (more on [AWS IoT](#aws-iot)):
 
 ```sh
-cloudiscovery aws-iot [--thing-name thing-xxxx] --region-name xx-xxxx-xxx [--profile-name profile] [--diagram [yes/no]] [--filter xxx] [--verbose]
+cloudiscovery aws iot [--thing-name thing-xxxx] --region-name xx-xxxx-xxx [--profile-name profile] [--diagram [yes/no]] [--filter xxx] [--verbose]
 ```
 
 1.4 To detect all AWS resources (more on [AWS All](#aws-all)):
 
 ```sh
-cloudiscovery aws-all --region-name xx-xxxx-xxx [--profile-name profile] [--services xxx,xxx] [--filter xxx] [--verbose]
+cloudiscovery aws all --region-name xx-xxxx-xxx [--profile-name profile] [--services xxx,xxx] [--filter xxx] [--verbose]
 ```
 
 1.5 To check AWS limits per resource (more on [AWS Limit](#aws-limit)):
 
 ```sh
-cloudiscovery aws-limit --region-name xx-xxxx-xxx [--profile-name profile] [--services xxx,xxx] [--usage 0-100] [--verbose]
+cloudiscovery aws limit --region-name xx-xxxx-xxx [--profile-name profile] [--services xxx,xxx] [--usage 0-100] [--verbose]
 ```
 
 1.6 To run AWS security controls (experimental feature):
 
 ```sh
-cloudiscovery aws-security --region-name xx-xxxx-xxx [--profile-name profile] [--commands x] [--verbose]
+cloudiscovery aws security --region-name xx-xxxx-xxx [--profile-name profile] [--commands x] [--verbose]
 ```
 
 2.  For help use:
 
 ```sh
-cloudiscovery [aws-vpc|aws-policy|aws-iot|aws-all|aws-limit] -h
+cloudiscovery [aws|az] [vpc|policy|iot|all|limit] -h
 ```
 
-### Debbuging 
+### Debugging 
 
 Enabling verbose mode, it is possible to debug all calls to the providers endpoints and check possible problems.
 
@@ -107,15 +113,23 @@ pip install -U cloudiscovery
 
 Once a while after installation, there can be some issues related with a cache from older version being used by a newer version. In that case, it's recommended to remove directory `./assets/.cache`.
 
-### AWS Credentials
+### Provider-specific dependencies
+| Provider | Dependency | URL |
+|:---------|:-----------|:----|
+|AWS|AWS CLI|https://aws.amazon.com/cli/|
+|Azure|Az CLI|https://docs.microsoft.com/en-us/cli/azure/install-azure-cli|
 
-Make sure you have properly configured your AWS-CLI with a valid Access Key and Region:
+### Credentials
 
-```sh
-aws configure
-```
+Credentials should be configured via the terminal before running the Cloudiscovery CLI.
 
-More on credentials configuration: [Configuration basics](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
+*Note* - Use of service principals are not currently supported
+
+| Provider | Command | Reference |
+|:---------|:--------|:----------|
+| AWS | `aws configure` | [AWS Docs](https://docs.aws.amazon.com/cli/latest/reference/configure/)
+| Azure | `az login` | [Microsoft Docs](https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli)
+
 
 #### AWS Permissions
 

--- a/cloudiscovery/__init__.py
+++ b/cloudiscovery/__init__.py
@@ -41,7 +41,7 @@ if sys.version_info < (3, 8):
     print("Python 3.8 or newer is required", file=sys.stderr)
     sys.exit(1)
 
-__version__ = "2.4.4"
+__version__ = "2.5.0"
 
 AVAILABLE_LANGUAGES = ["en_US", "pt_BR"]
 

--- a/cloudiscovery/__init__.py
+++ b/cloudiscovery/__init__.py
@@ -41,7 +41,7 @@ if sys.version_info < (3, 8):
     print("Python 3.8 or newer is required", file=sys.stderr)
     sys.exit(1)
 
-__version__ = "2.5.0"
+__version__ = "3.0.0"
 
 AVAILABLE_LANGUAGES = ["en_US", "pt_BR"]
 

--- a/cloudiscovery/provider/aws/command.py
+++ b/cloudiscovery/provider/aws/command.py
@@ -115,36 +115,36 @@ def aws_main(args) -> BaseCommand:
                 if int(args.threshold) < 0 or int(args.threshold) > 100:
                     exit_critical("Threshold must be between 0 and 100")
 
-    if args.command == "aws-vpc":
+    if args.resource == "vpc":
         command = Vpc(
             vpc_id=args.vpc_id,
             region_names=region_names,
             session=session,
             partition_code=partition_code,
         )
-    elif args.command == "aws-policy":
+    elif args.resource == "policy":
         command = Policy(
             region_names=region_names, session=session, partition_code=partition_code
         )
-    elif args.command == "aws-iot":
+    elif args.resource == "iot":
         command = Iot(
             thing_name=args.thing_name,
             region_names=region_names,
             session=session,
             partition_code=partition_code,
         )
-    elif args.command == "aws-all":
+    elif args.resource == "all":
         command = All(
             region_names=region_names, session=session, partition_code=partition_code
         )
-    elif args.command == "aws-limit":
+    elif args.resource == "limit":
         command = Limit(
             region_names=region_names,
             session=session,
             threshold=args.threshold,
             partition_code=partition_code,
         )
-    elif args.command == "aws-security":
+    elif args.resource == "security":
         command = Security(
             region_names=region_names,
             session=session,

--- a/cloudiscovery/shared/parameters.py
+++ b/cloudiscovery/shared/parameters.py
@@ -18,37 +18,41 @@ def generate_parser():
 
     subparsers = parser.add_subparsers(help="commands", dest="command")
 
-    vpc_parser = subparsers.add_parser("aws-vpc", help="Analyze VPCs")
-    add_default_arguments(vpc_parser)
-    vpc_parser.add_argument(
+    # Begin AWS "aws" parser declarations
+    aws_parser = subparsers.add_parser("aws", help="aws help")
+    aws_subparser = aws_parser.add_subparsers(title="AWS Discovery", dest="resource")
+
+    aws_vpc_parser = aws_subparser.add_parser("vpc", help="aws vpc help")
+    add_default_arguments(aws_vpc_parser)
+    aws_vpc_parser.add_argument(
         "-v",
         "--vpc-id",
         required=False,
         help="Inform VPC to analyze. If not informed, script will check all vpcs.",
     )
 
-    iot_parser = subparsers.add_parser("aws-iot", help="Analyze IoTs")
-    add_default_arguments(iot_parser)
-    iot_parser.add_argument(
+    aws_iot_parser = aws_subparser.add_parser("iot", help="aws iot help")
+    add_default_arguments(aws_iot_parser)
+    aws_iot_parser.add_argument(
         "-t",
         "--thing-name",
         required=False,
         help="Inform Thing Name to analyze. If not informed, script will check all things inside a region.",
     )
 
-    policy_parser = subparsers.add_parser("aws-policy", help="Analyze policies")
-    add_default_arguments(policy_parser, is_global=True)
+    aws_policy_parser = aws_subparser.add_parser("policy", help="aws policy help")
+    add_default_arguments(aws_policy_parser, is_global=True)
 
-    all_parser = subparsers.add_parser("aws-all", help="Analyze all resources")
-    add_default_arguments(all_parser, diagram_enabled=False)
-    add_services_argument(all_parser)
+    aws_all_parser = aws_subparser.add_parser("all", help="aws all help")
+    add_default_arguments(aws_all_parser, diagram_enabled=False)
+    add_services_argument(aws_all_parser)
 
-    limit_parser = subparsers.add_parser(
-        "aws-limit", help="Analyze aws limit resources."
+    aws_limit_parser = aws_subparser.add_parser("limit", help="aws limit help")
+    add_default_arguments(
+        aws_limit_parser, diagram_enabled=False, filters_enabled=False
     )
-    add_default_arguments(limit_parser, diagram_enabled=False, filters_enabled=False)
-    add_services_argument(limit_parser)
-    limit_parser.add_argument(
+    add_services_argument(aws_limit_parser)
+    aws_limit_parser.add_argument(
         "-t",
         "--threshold",
         required=False,
@@ -56,11 +60,11 @@ def generate_parser():
               For example: --threshold 50 will report all resources with more than 50%% threshold.",
     )
 
-    security_parser = subparsers.add_parser(
-        "aws-security", help="Analyze aws several security checks."
+    aws_security_parser = aws_subparser.add_parser("security", help="aws security help")
+    add_default_arguments(
+        aws_security_parser, diagram_enabled=False, filters_enabled=False
     )
-    add_default_arguments(security_parser, diagram_enabled=False, filters_enabled=False)
-    security_parser.add_argument(
+    aws_security_parser.add_argument(
         "-c",
         "--commands",
         action="append",
@@ -69,6 +73,14 @@ def generate_parser():
               To see available commands, please type "-c list". \
               If not passed, command will check all services.',
     )
+
+    # Begin Azure "az" parser declaration
+    az_parser = subparsers.add_parser("az", help="az help")
+    az_subparser = az_parser.add_subparsers(title="Azure Discovery", dest="resource")
+
+    az_all_parser = az_subparser.add_parser("all", help="az all help")
+    add_default_arguments(az_all_parser, diagram_enabled=False)
+    add_services_argument(az_all_parser)
 
     return parser
 


### PR DESCRIPTION
The purpose of this PR is to refactor the CLI to support multiple cloud providers. The changes proposed here will provide benefits in the following manners:

- The argparser has been updated to nest subparsers under cloud providers
  - <provider> (aws | az) <resource> (vpc | security | etc.)
- Allows for future standardization of resource arguments (not part of this PR)
  - Instead of provider-specific resource calls, generalize them: 
    - `cloudiscovery aws network --vpc-id vpc-xxxxxxxx`
    - `cloudiscovery az network --vnet-name my-vnet`

*Note* - This is a breaking change for any automated implementations of Cloudiscovery. Commands such as `aws-vpc` and similar are no longer supported in this refactor. 

This is to be the first of a series of pull requests to begin enabling multi-cloud provider support.