### PR TITLE
Fix shell command on macOS and Linux for venv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ When developing, it's recommended to use [venv](https://docs.python.org/3/librar
 
 In order to create a venv on macOS and Linux:
 ```sh
-python3 -m venv env
+python3 -m venv venv
 ```
 On Windows:
 ```sh


### PR DESCRIPTION
Tiny fix in README. `venv` is expected name for a directory, because it is used later when activating with [`source venv/bin/activate`](https://github.com/Cloud-Architects/cloudiscovery/blob/fad132e45f813775eaf0051e628fcbec68291fb4/README.md#L375) command and this directory is ignored in  [.gitignore#L37](https://github.com/Cloud-Architects/cloudiscovery/blob/fad132e45f813775eaf0051e628fcbec68291fb4/.gitignore)