### PR TITLE
Docker build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,6 @@ RUN apt-get install -y bash
 COPY . /opt/cloudiscovery
 
 RUN pip install -r requirements.txt
+RUN ./setup.py build && ./setup.py install && ./setup.py bdist
 
-RUN bash
+CMD bash

--- a/cloudiscovery/provider/aws/common_aws.py
+++ b/cloudiscovery/provider/aws/common_aws.py
@@ -93,7 +93,7 @@ class GlobalParameters:
                 ),
                 "HEADER",
             )
-            self.client = self.session.client("ssm", region_name="us-east-1")
+            self.client = self.session.client("ssm", region_name=self.region)
             paths = self.parameters()
             for path in paths:
                 paths_found.append(path["Value"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ diagrams>=0.14
 cachetools
 diskcache
 pytz
+markupsafe==2.0.1


### PR DESCRIPTION
- Fix for #186 (missing dependency)
- Fixed hardcoded region preventing it from working outside us-east-1
- Added installation steps inside Dockerfile so that the cloudiscovery executable is available in the container